### PR TITLE
 Fixed link to smtpMailerOOo.oxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This extension is necessary to use HsqlDB version 2.5.1 with all its features.
 
 This extension is only needed if you want to use your personal phone contacts (Android contact) as a data source for mailing lists and document merging.
 
-- Install [smtpMailerOOo.oxt](https://github.com/prrvchr/smtpMailerOOo/raw/main/smtpMailerOOo.oxt) extension version 0.0.1.
+- Install [smtpMailerOOo.oxt](https://github.com/prrvchr/smtpMailerOOo/raw/master/smtpMailerOOo.oxt) extension version 0.0.1.
 
 Restart LibreOffice / OpenOffice after installation.
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -73,7 +73,7 @@ Cette extension est nécessaire pour utiliser HsqlDB version 2.5.1 avec toutes s
 
 Cette extension n'est nécessaire que si vous souhaitez utiliser vos contacts téléphoniques personnels (contact Android) comme source de données pour les listes de diffusion et la fusion de documents.
 
-- Installer l'extension [smtpMailerOOo.oxt](https://github.com/prrvchr/smtpMailerOOo/raw/main/smtpMailerOOo.oxt) version 0.0.1.
+- Installer l'extension [smtpMailerOOo.oxt](https://raw.githubusercontent.com/prrvchr/smtpMailerOOo/master/smtpMailerOOo.oxt) version 0.0.1.
 
 Redémarrez LibreOffice / OpenOffice après l'installation.
 


### PR DESCRIPTION
Fixed link to smtpMailerOOo.oxt by changing 'main' (non-existent) to 'master' in README.md and README_fr.md